### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/quarto-publish.yml
+++ b/.github/workflows/quarto-publish.yml
@@ -9,6 +9,9 @@ on:
 
 name: Render and Publish
 
+permissions:
+  contents: write
+
 jobs:
   build-deploy:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/bcgov/ds-intro-to-python/security/code-scanning/1](https://github.com/bcgov/ds-intro-to-python/security/code-scanning/1)

Add an explicit `permissions:` block in `.github/workflows/quarto-publish.yml` so the workflow documents and enforces least privilege.  
Best single fix without changing behavior: define permissions at workflow root (applies to all jobs) with:
- `contents: write` (needed to push/publish to `gh-pages`)
- optionally `pages: write` is not required here because this action targets `gh-pages` branch publishing, not the Pages deployment API.
- `id-token` not needed for this current workflow.

Edit location: immediately after `name: Render and Publish` and before `jobs:`.

No imports, methods, or dependencies are needed (YAML-only change).


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
